### PR TITLE
changed event.eventType.getLabel match to use event.eventType.getId

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,9 @@ lazy val cmdLine = (project in file("cmdLine")).
       scalaVersion := "2.13.1"
     )),
     name := "TopGun-cmdline",
-    libraryDependencies += "args4j" % "args4j" % "2.33"
+    libraryDependencies += "args4j" % "args4j" % "2.33",
+    libraryDependencies += "org.ow2.asm" % "asm" % "9.0",
+    libraryDependencies += "org.ow2.asm" % "asm-tree" % "9.0"
   ).dependsOn(core)
 
 lazy val core = (project in file("core")).

--- a/cmdLine/src/main/scala/topgun/cmdline/Configuration.scala
+++ b/cmdLine/src/main/scala/topgun/cmdline/Configuration.scala
@@ -35,7 +35,6 @@ class Configuration(cmdLine: JfrParseCommandLine) {
     case (_, _) => ???
   }
 
-
   val ignoredStack = if (cmdLine.ignoreContainingFrames eq null) Nil else {
     Files.readAllLines(cmdLine.ignoreContainingFrames.toPath).asScala.toList
   }
@@ -63,6 +62,4 @@ class Configuration(cmdLine: JfrParseCommandLine) {
     }
     include
   }
-
-
 }

--- a/cmdLine/src/main/scala/topgun/cmdline/FileWriter.scala
+++ b/cmdLine/src/main/scala/topgun/cmdline/FileWriter.scala
@@ -120,4 +120,3 @@ object FileWriter {
     files.clear()
   }
 }
-

--- a/cmdLine/src/main/scala/topgun/cmdline/JfrEventNotFoundException.java
+++ b/cmdLine/src/main/scala/topgun/cmdline/JfrEventNotFoundException.java
@@ -1,0 +1,10 @@
+package topgun.cmdline;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+
+public class JfrEventNotFoundException extends Exception{
+    public JfrEventNotFoundException(String s) {
+        super(s);
+    }
+}

--- a/cmdLine/src/main/scala/topgun/cmdline/JfrParse.scala
+++ b/cmdLine/src/main/scala/topgun/cmdline/JfrParse.scala
@@ -14,6 +14,7 @@ object JfrParse extends App {
   } catch {
     case e: CmdLineException =>
       // handling of wrong arguments
+
       System.err.println(e.getMessage)
       parser.printUsage(System.err)
   }

--- a/cmdLine/src/main/scala/topgun/cmdline/JfrReader.scala
+++ b/cmdLine/src/main/scala/topgun/cmdline/JfrReader.scala
@@ -24,7 +24,7 @@ class JfrReader(cmdLine: JfrParseCommandLine) {
     val files:List[File] = if (cmdLine.jfr.isDirectory)
       cmdLine.jfr.listFiles().toList.filter(f => f.isFile && f.getName.endsWith(".jfr"))
     else List(cmdLine.jfr)
-    
+
     files.foreach {file =>
       new FileParser(file, cmdLine, totals, configuration).parse()
     }
@@ -75,5 +75,4 @@ class JfrReader(cmdLine: JfrParseCommandLine) {
     System.out.println(s"Allocation - ignored (stack)  ${totals.ignoredStackAllocationEvents}  events")
     System.out.println(s"Allocation - ignored (thread) ${totals.ignoredThreadAllocationEvents}  events")
   }
-
 }


### PR DESCRIPTION
@Johnnywoode 
- [x] changed event.eventType.getLabel match to use event.eventType.getId

Reason: Event Labels may be changed over time but eventType ids will not

